### PR TITLE
Controllable alpha value

### DIFF
--- a/scripts/daam/utils.py
+++ b/scripts/daam/utils.py
@@ -32,8 +32,8 @@ def expand_image(im: torch.Tensor, h = 512, w = 512,  absolute: bool = False, th
 
     return im.squeeze()
 
-def image_overlay_heat_map(im, heat_map, word=None, out_file=None, crop=None):
-    # type: (Image.Image | np.ndarray, torch.Tensor, str, Path, int) -> Image.Image
+def image_overlay_heat_map(im, heat_map, word=None, out_file=None, crop=None, alpha=0.5):
+    # type: (Image.Image | np.ndarray, torch.Tensor, str, Path, int, float) -> Image.Image
 
     # im = im.numpy().array()
         
@@ -43,7 +43,7 @@ def image_overlay_heat_map(im, heat_map, word=None, out_file=None, crop=None):
     heat_map = heat_map.to('cpu').detach().numpy().copy().astype(np.uint8)
     heat_map_img = Image.fromarray(heat_map)
         
-    return Image.blend(im, heat_map_img, 0.5)
+    return Image.blend(im, heat_map_img, alpha)
     
 
 def _convert_heat_map_colors(heat_map : torch.Tensor):

--- a/scripts/daam_script.py
+++ b/scripts/daam_script.py
@@ -29,19 +29,23 @@ class Script(scripts.Script):
         attention_texts = gr.Text(label='Attention texts for visualization. (comma separated)', value='')
 
         hide_images = gr.Checkbox(label='Hide heatmap images', value=False)
+
+        alpha = gr.Slider(label='Blend', value=0.5, minimum=0, maximum=1, step=0.01)
         
         self.tracer = None
         self.attentions = []
         self.images = []
         self.hide_images = hide_images
+        self.alpha = alpha
         
-        return [attention_texts, hide_images]
+        return [attention_texts, hide_images, alpha]
     
-    def run(self, p : StableDiffusionProcessing, attention_texts : str, hide_images : bool):
+    def run(self, p : StableDiffusionProcessing, attention_texts : str, hide_images : bool, alpha : float):
 
         initial_info = None
         self.images = []
         self.hide_images = hide_images
+        self.alpha = alpha
         
         fix_seed(p)
         
@@ -91,7 +95,7 @@ class Script(scripts.Script):
                                
                     img_size = params.image.size
                     heat_map = utils.expand_image(global_heat_map.compute_word_heat_map(attention), img_size[1], img_size[0])
-                    img : Image.Image = utils.image_overlay_heat_map(params.image, heat_map)
+                    img : Image.Image = utils.image_overlay_heat_map(params.image, heat_map, alpha=self.alpha)
                     
                     fullfn_without_extension, extension = os.path.splitext(params.filename)
                 


### PR DESCRIPTION
Adds a slider to control the alpha value in `image_overlay_heat_map` from 0 to 1. Useful to increase/decrease the background image's opacity, or to remove it entirely by setting the value to 1.