### PR TITLE
add mps support

### DIFF
--- a/scripts/daam/trace.py
+++ b/scripts/daam/trace.py
@@ -4,6 +4,7 @@ from copy import deepcopy
 from pathlib import Path
 from typing import List, Type, Any, Literal, Dict
 import math
+from modules.devices import device
 
 from ldm.models.diffusion.ddpm import DiffusionWrapper, LatentDiffusion
 from ldm.modules.diffusionmodules.openaimodel import UNetModel
@@ -178,7 +179,7 @@ class DiffusionHeatMapHooker(AggregateHooker):
                all_merges.append(merge_list)
 
         maps = torch.stack([torch.stack(x, 0) for x in all_merges], dim=0)
-        maps = maps.sum(0).cuda().sum(2).sum(0)
+        maps = maps.sum(0).to(device).sum(2).sum(0)
 
         return HeatMap(self.model, prompt, maps)
 

--- a/scripts/daam/utils.py
+++ b/scripts/daam/utils.py
@@ -11,6 +11,7 @@ import numpy as np
 # import spacy
 import torch
 import torch.nn.functional as F
+from modules.devices import dtype
 
 from ldm.modules.encoders.modules import FrozenCLIPEmbedder, FrozenOpenCLIPEmbedder
 import open_clip.tokenizer
@@ -103,7 +104,7 @@ def _convert_heat_map_colors(heat_map : torch.Tensor):
         return color_gradients[0][1:]
     
     color_map = np.array([ get_color(i) * 255 for i in range(256) ])
-    color_map = torch.tensor(color_map, device=heat_map.device)
+    color_map = torch.tensor(color_map, device=heat_map.device, dtype=dtype)
     
     heat_map = (heat_map * 255).long()
     


### PR DESCRIPTION
Users on MacOS won't have cuda enabled, causing the extension to crash. This PR solves that.

This PR changes the extension to use whatever device and dtype the rest of the webui is using.