### PR TITLE
matplotlib fix

### DIFF
--- a/install.py
+++ b/install.py
@@ -1,0 +1,3 @@
+import launch
+if not launch.is_installed('matplotlib'):
+    launch.run_pip('install matplotlib==3.6.2', desc='Installing matplotlib==3.6.2')


### PR DESCRIPTION
Adds an `install.py`-file which ensures matplotlib can use the `turbo` colormap.

Fixes #18 
Fixes #14