### PR TITLE
Fix incorrect calc_word_indecies when used loras

### DIFF
--- a/scripts/daam/trace.py
+++ b/scripts/daam/trace.py
@@ -46,10 +46,10 @@ class UNetForwardHooker(ObjectHooker[UNetModel]):
 
 
 class HeatMap:
-    def __init__(self, prompt_analyzer: PromptAnalyzer, prompt: str, heat_maps: torch.Tensor):
-        self.prompt_analyzer = prompt_analyzer.create(prompt)
+    def __init__(self, prompt_analyzer: PromptAnalyzer, heat_maps: torch.Tensor):
+        self.prompt_analyzer = prompt_analyzer
         self.heat_maps = heat_maps
-        self.prompt = prompt
+        self.prompt = prompt_analyzer.prompt
 
     def compute_word_heat_map(self, word: str, word_idx: int = None) -> torch.Tensor:
         merge_idxs, _ = self.prompt_analyzer.calc_word_indecies(word)
@@ -182,7 +182,7 @@ class DiffusionHeatMapHooker(AggregateHooker):
         maps = torch.stack([torch.stack(x, 0) for x in all_merges], dim=0)
         maps = maps.sum(0).to(device).sum(2).sum(0)
 
-        return HeatMap(prompt_analyzer, prompt, maps)
+        return HeatMap(prompt_analyzer, maps)
 
 
 class UNetCrossAttentionHooker(ObjectHooker[CrossAttention]):

--- a/scripts/daam/utils.py
+++ b/scripts/daam/utils.py
@@ -4,6 +4,7 @@ from functools import lru_cache
 from pathlib import Path
 import random
 import re
+import sys
 from typing import Union
 
 from PIL import Image, ImageFont, ImageDraw
@@ -276,6 +277,7 @@ class PromptAnalyzer:
         self.used_custom_terms = []
         self.hijack_comments = []
 
+        self.prompt = text
         chunks, token_count = self.tokenize_line(text)
 
         self.token_count = token_count


### PR DESCRIPTION
Before saving the images, a prompt with undeleted <lora:.*> inserts was taken, although initially a prompt without them was provided. I removed the prompt override, and now the search for indexes is based on the correct prompt.