### PR TITLE
Feature: API & Override Settings support

### DIFF
--- a/scripts/daam/__init__.py
+++ b/scripts/daam/__init__.py
@@ -4,3 +4,4 @@ from .utils import *
 from .evaluate import *
 from .experiment import *
 from .trace import *
+from .api import *

--- a/scripts/daam/api.py
+++ b/scripts/daam/api.py
@@ -1,0 +1,27 @@
+from fastapi import FastAPI, Form
+import gradio as gr
+
+api_attention_texts: str | None = None
+
+
+def daam_api(_: gr.Blocks, app: FastAPI):
+    @app.post("/daam/v1/set-attention-text")
+    async def set_daam_attention_text(
+            texts: str = Form(description="Attention Texts for visualization")
+    ):
+        global api_attention_texts
+        api_attention_texts = None if len(texts) == 0 else texts
+
+    @app.get("/daam/v1/get-attention-text")
+    async def return_daam_attention_text():
+        return {
+            "texts": api_attention_texts
+        }
+
+
+try:
+    from modules import script_callbacks
+
+    script_callbacks.on_app_started(daam_api)
+except:
+    print("[stable-diffusion-webui-daam] API failed to initialize")

--- a/scripts/daam_script.py
+++ b/scripts/daam_script.py
@@ -20,7 +20,7 @@ from modules.shared import cmd_opts, opts, state
 import modules.shared as shared
 from PIL import Image
 
-from scripts.daam import trace, utils
+from scripts.daam import trace, utils, api_attention_texts
 
 before_image_saved_handler = None
 
@@ -70,8 +70,8 @@ class Script(scripts.Script):
         
         self.tracers = None
         
-        return [attention_texts, hide_images, dont_save_images, hide_caption, use_grid, grid_layouyt, alpha, heatmap_image_scale, trace_each_layers, layers_as_row] 
-    
+        return [attention_texts, hide_images, dont_save_images, hide_caption, use_grid, grid_layouyt, alpha, heatmap_image_scale, trace_each_layers, layers_as_row]
+
     def process(self, 
             p : StableDiffusionProcessing, 
             attention_texts : str, 
@@ -87,6 +87,9 @@ class Script(scripts.Script):
         
         self.enabled = False # in case the assert fails
         assert opts.samples_save, "Cannot run Daam script. Enable 'Always save all generated images' setting."
+
+        if api_attention_texts:
+            attention_texts = api_attention_texts
 
         self.images = []
         self.hide_images = hide_images

--- a/scripts/daam_script.py
+++ b/scripts/daam_script.py
@@ -23,6 +23,7 @@ from PIL import Image
 from scripts.daam import trace, utils, api_attention_texts
 
 before_image_saved_handler = None
+override_attention_texts: str | None = None
 
 class Script(scripts.Script):
     
@@ -72,7 +73,17 @@ class Script(scripts.Script):
         
         return [attention_texts, hide_images, dont_save_images, hide_caption, use_grid, grid_layouyt, alpha, heatmap_image_scale, trace_each_layers, layers_as_row]
 
-    def process(self, 
+    def before_process(self, p, *args):
+        global override_attention_texts
+        if "daam-texts" in p.override_settings:
+            texts = p.override_settings["daam-texts"]
+            if texts is not None:
+                override_attention_texts = p.override_settings["daam-texts"]
+                del p.override_settings["daam-texts"]
+                return
+        override_attention_texts = None
+
+    def process(self,
             p : StableDiffusionProcessing, 
             attention_texts : str, 
             hide_images : bool, 
@@ -88,7 +99,11 @@ class Script(scripts.Script):
         self.enabled = False # in case the assert fails
         assert opts.samples_save, "Cannot run Daam script. Enable 'Always save all generated images' setting."
 
-        if api_attention_texts:
+        global override_attention_texts
+        if override_attention_texts:
+            attention_texts = override_attention_texts
+            override_attention_texts = None
+        elif api_attention_texts:
             attention_texts = api_attention_texts
 
         self.images = []


### PR DESCRIPTION
Adds support to change attention texts used by daam through either the api or override settings.
This should help when you only need to check a couple texts, and not the entire prompt.

**API:**
`/daam/v1/set-attention-text`  
Providing an empty string will clear attention texts to use. Otherwise, it will use it as the source of attention texts.  

`/daam/v1/get-attention-text`  
Gets the current attention texts set through the API.  

**Override Settings:**
Pass texts through `daam-texts` within `override_settings`.

Override settings has priority over the API